### PR TITLE
Dynamic scale down

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source :gemcutter
 
+gem 'coveralls', require: false
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source :gemcutter
 
 gem 'coveralls', require: false
+gem 'simplecov', require: false
 
 gemspec

--- a/lib/workless/scalers/heroku_cedar.rb
+++ b/lib/workless/scalers/heroku_cedar.rb
@@ -11,7 +11,10 @@ module Delayed
         end
 
         def self.down
-          client.post_ps_scale(ENV['APP_NAME'], 'worker', self.min_workers) unless self.workers == self.min_workers or self.jobs.count > 0
+          workers = self.workers
+          unless workers == self.min_workers or workers <= self.workers_needed
+           client.post_ps_scale(ENV['APP_NAME'], 'worker', self.workers_needed)
+          end
         end
 
         def self.workers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@ require 'bundler/setup'
 
 Bundler.require(:default)
 
+require 'coveralls'
+Coveralls.wear!
+
 require 'workless'
 
 module Delayed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,15 @@
 require 'rubygems'
 require 'bundler/setup'
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+SimpleCov.start
 
 Bundler.require(:default)
-
-require 'coveralls'
-Coveralls.wear!
 
 require 'workless'
 

--- a/spec/workless/mongoid_scaling_spec.rb
+++ b/spec/workless/mongoid_scaling_spec.rb
@@ -56,13 +56,11 @@ describe Delayed::Mongoid::Job do
 
         Delayed::Mongoid::Job::Mock.scaler.down
       end
-      pending "This will be a new feature" do
-        it "should scale down to 1" do
-          if_there_are_jobs 1
-          should_scale_workers_to 1
+      it "should scale down to 1" do
+        if_there_are_jobs 1
+        should_scale_workers_to 1
 
-          Delayed::Mongoid::Job::Mock.scaler.down
-        end
+        Delayed::Mongoid::Job::Mock.scaler.down
       end
     end
   end

--- a/spec/workless/scalers/heroku_cedar_spec.rb
+++ b/spec/workless/scalers/heroku_cedar_spec.rb
@@ -61,7 +61,7 @@ describe Delayed::Workless::Scaler::HerokuCedar do
     context 'with workers' do
 
       before do
-        Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).and_return(NumWorkers.new(10))
+        Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).and_return(10)
       end
 
       it 'should set the workers to 0' do


### PR DESCRIPTION
Scale down the workers when no more are needed...

This may result in a lot of queries, but it reduces the costs of the workers on Heroku, when 1 long running proces keeps a lot of workers up...
